### PR TITLE
Simplification of the Button component

### DIFF
--- a/mobile/src/components/Button.tsx
+++ b/mobile/src/components/Button.tsx
@@ -1,32 +1,34 @@
 import { ReactNode } from "react";
-import { GestureResponderEvent, Pressable, Text } from "react-native";
+import { Pressable, Text, PressableProps } from "react-native";
 
-interface Props {
+interface Props extends PressableProps {
   name: string;
-  className: string;
-  children: ReactNode[];
-  onPress: (event: GestureResponderEvent) => void;
+  className?: string;
+  children?: ReactNode;
   disabled?: boolean;
   pilled?: boolean;
 }
 
 /**
- * buttonName - name of the button.
- * addButtonStyle - add custom style to the button.
- * children - if you want to add your own text with styles.
- * pilled - make the button pilled (optional).
- * disabled - greys out button (optional).
+ * name - (string) button text (required).
+ * className - (string) additional button styling (required).
+ * children - (jsx tags/component)(optional) ie. pass in an icon (optional).
+ * onPress - (function) button click handler. (optional) (default: ()=>{})
+ * disabled - (boolean) calling this in the prop will grey the button out(optional).
+ * pilled - (boolean) calling this will round the button all the way(optional).
  */
+
 export default function Button({
   name,
-  className,
-  children,
-  onPress,
+  className = "",
+  children = null,
   disabled = false,
   pilled = false,
+  ...props
 }: Props) {
-  let baseStyle = "h-7 items-center justify-center";
-  let textStyle = "text-white margin mx-5 font-semibold";
+  //warning: do not touch the extra spaces at the end or it will break the styling
+  let baseStyle = "h-7 items-center justify-center ";
+  let textStyle = "text-white margin mx-5 font-semibold ";
 
   if (disabled) {
     baseStyle += "text-slate-50 bg-indigo-900/40 hover:bg-indigo-900/80";
@@ -36,12 +38,13 @@ export default function Button({
   }
   if (pilled) {
     baseStyle += "rounded-full";
+    console.log(baseStyle);  
   } else {
     baseStyle += "rounded-md";
   }
 
   return (
-    <Pressable onPress={onPress} className={`${baseStyle} ${className}`}>
+    <Pressable className={`${baseStyle} ${className}`} {...props}>
       {name && <Text className={textStyle}>{name}</Text>}
       {children}
     </Pressable>

--- a/mobile/src/components/Button.tsx
+++ b/mobile/src/components/Button.tsx
@@ -26,21 +26,20 @@ export default function Button({
   pilled = false,
   ...props
 }: Props) {
-  //warning: do not touch the extra spaces at the end or it will break the styling
-  let baseStyle = "h-7 items-center justify-center ";
+  //warning: do not touch the extra spaces at the beginning or it will break the styling
+  let baseStyle = "h-7 items-center justify-center";
   let textStyle = "text-white margin mx-5 font-semibold";
 
   if (disabled) {
-    baseStyle += "text-slate-50 bg-indigo-900/40 hover:bg-indigo-900/80";
+    baseStyle += " text-slate-50 bg-indigo-900/40 hover:bg-indigo-900/80";
   } else {
     baseStyle +=
-      "text-slate-50 bg-indigo-900 hover:bg-indigo-800 active:opacity-70";
+      " text-slate-50 bg-indigo-900 hover:bg-indigo-800 active:opacity-70";
   }
   if (pilled) {
-    baseStyle += "rounded-full";
-    console.log(baseStyle);
+    baseStyle += " rounded-full";
   } else {
-    baseStyle += "rounded-md";
+    baseStyle += " rounded-md";
   }
 
   return (

--- a/mobile/src/components/Button.tsx
+++ b/mobile/src/components/Button.tsx
@@ -28,7 +28,7 @@ export default function Button({
 }: Props) {
   //warning: do not touch the extra spaces at the end or it will break the styling
   let baseStyle = "h-7 items-center justify-center ";
-  let textStyle = "text-white margin mx-5 font-semibold ";
+  let textStyle = "text-white margin mx-5 font-semibold";
 
   if (disabled) {
     baseStyle += "text-slate-50 bg-indigo-900/40 hover:bg-indigo-900/80";
@@ -38,7 +38,7 @@ export default function Button({
   }
   if (pilled) {
     baseStyle += "rounded-full";
-    console.log(baseStyle);  
+    console.log(baseStyle);
   } else {
     baseStyle += "rounded-md";
   }


### PR DESCRIPTION
Changes:
  * props extends pressable props so now we can use any of those methods and not just OnPress,
  * ClassName is for additional styles and that is optional,
  * Children changed to optional, sometimes you only want to pass in text which can be done with `name = "name"`
  * Children changed from from ReactNode[] to ReactNode, its just simpler this way to keeping it to one component being passed in.

Bugfix:
  * adding back the space to the end of the baseStyle string because that string does get modified
 
ww. :@Rikimbili
