### PR TITLE
Get auth working

### DIFF
--- a/web/src/pages/api/addPostToCollection.ts
+++ b/web/src/pages/api/addPostToCollection.ts
@@ -1,15 +1,13 @@
 import { PrismaClient } from "@prisma/client";
 import { NextApiRequest, NextApiResponse } from "next";
 
-import { getServerAuthSession } from "../../server/common/get-server-auth-session";
+import { validateRequest } from "../../utils/jwt";
 
 export default async function addPostToCollection(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  const session = await getServerAuthSession({ req, res });
-
-  if (!session) {
+  if (!(await validateRequest(req))) {
     res.statusCode = 401;
     res.json({ Error: "User not logged in." });
     return;

--- a/web/src/utils/jwt.ts
+++ b/web/src/utils/jwt.ts
@@ -38,6 +38,13 @@ export const validateRequest = async (
   const authHeader = req.headers.authorization;
   const matches = authHeader?.match(/Bearer: (.*)/);
   const jwt = matches?.[1];
+  return validateJWT(userId, jwt);
+};
+
+export const validateJWT = async (
+  userId: string,
+  jwt: string | undefined
+): Promise<boolean> => {
   return new Promise((resolve) => {
     if (!jwt) {
       throw Error("jwt should not be falsy!");

--- a/web/src/utils/jwt.ts
+++ b/web/src/utils/jwt.ts
@@ -39,7 +39,10 @@ export const validateRequest = async (
   const matches = authHeader?.match(/Bearer: (.*)/);
   const jwt = matches?.[1];
   return new Promise((resolve) => {
-    if (!jwt || !process.env.JWT_PRIVATE_KEY) {
+    if (!jwt) {
+      throw Error("jwt should not be falsy!");
+    }
+    if (!process.env.JWT_PRIVATE_KEY) {
       throw Error("Missing environment variable process.env.JWT_PRIVATE_KEY");
     }
     verify(jwt, process.env.JWT_PRIVATE_KEY, (err, data) => {

--- a/web/src/utils/jwt.ts
+++ b/web/src/utils/jwt.ts
@@ -8,7 +8,7 @@ export const generateJWT = async (username: string): Promise<string> => {
       throw Error("Missing environment variable process.env.JWT_PRIVATE_KEY");
     }
     sign(
-      username,
+      { username },
       process.env.JWT_PRIVATE_KEY,
       { expiresIn: "1 day" },
       (err, data) => {
@@ -43,7 +43,8 @@ export const validateRequest = async (
       throw Error("Missing environment variable process.env.JWT_PRIVATE_KEY");
     }
     verify(jwt, process.env.JWT_PRIVATE_KEY, (err, data) => {
-      resolve(!err && data === userId);
+      const username = (data as { username: string }).username;
+      resolve(!err && username === userId);
     });
   });
 };


### PR DESCRIPTION
This PR gets authentication with the JWTs fully working AFAIK.

All: You will need to grab the JWT secret from #announcements in discord. It goes in `.env`.

Frontend: You will need to hit the `/api/Register` and `/api/Login` endpoints to get a JWT. You will then need to add this to the authorization header of your requests once backend implements the auth.

Backend: You will need to add support for the JWT auth in your endpoint. Simply mark your endpoint as `async` and call `await validateRequest(req)` to get a boolean that indicates if the request is valid or not. There is an example in `/api/addPostToCollection.ts`.

There will be some issues with endpoints that rely on nextauth session functionality to grab things like the userId. The suggested workaround is to take any such parameters via the query params or the body.

Also, open to discussion on how to work around this in development. (`if (process.env.DEVELOPMENT) { // don't validate }`)?