### PR TITLE
fix: remove misleading className from Button

### DIFF
--- a/mobile/src/components/Button.tsx
+++ b/mobile/src/components/Button.tsx
@@ -3,7 +3,6 @@ import { Pressable, Text, PressableProps } from "react-native";
 
 interface Props extends PressableProps {
   name: string;
-  className?: string;
   children?: ReactNode;
   disabled?: boolean;
   pilled?: boolean;
@@ -11,7 +10,6 @@ interface Props extends PressableProps {
 
 /**
  * name - (string) button text (required).
- * className - (string) additional button styling (required).
  * children - (jsx tags/component)(optional) ie. pass in an icon (optional).
  * onPress - (function) button click handler. (optional) (default: ()=>{})
  * disabled - (boolean) calling this in the prop will grey the button out(optional).
@@ -20,7 +18,6 @@ interface Props extends PressableProps {
 
 export default function Button({
   name,
-  className = "",
   children = null,
   disabled = false,
   pilled = false,
@@ -43,7 +40,7 @@ export default function Button({
   }
 
   return (
-    <Pressable className={`${baseStyle} ${className}`} {...props}>
+    <Pressable className={baseStyle} {...props}>
       {name && <Text className={textStyle}>{name}</Text>}
       {children}
     </Pressable>

--- a/mobile/src/components/Button.tsx
+++ b/mobile/src/components/Button.tsx
@@ -1,3 +1,4 @@
+import { styled } from "nativewind";
 import { ReactNode } from "react";
 import { Pressable, Text, PressableProps } from "react-native";
 
@@ -16,7 +17,7 @@ interface Props extends PressableProps {
  * pilled - (boolean) calling this will round the button all the way(optional).
  */
 
-export default function Button({
+function Button({
   name,
   children = null,
   disabled = false,
@@ -46,3 +47,5 @@ export default function Button({
     </Pressable>
   );
 }
+
+export default styled(Button);


### PR DESCRIPTION
This code currently works, but not because of the className prop. Nativewind compiles the className prop into style, and the rest parameter catches the style prop and applies that. This commit removes the useless and misleading className prop.