### PR TITLE
Web - Enforce png images for profiles

### DIFF
--- a/web/src/components/Layout/Profile/CreatedCollectionList.tsx
+++ b/web/src/components/Layout/Profile/CreatedCollectionList.tsx
@@ -43,6 +43,7 @@ export default function CreatedCollectionList({
     onError: (err: Error) => {
       toast.error(err.message);
     },
+    refetchOnMount: "always",
     enabled: !!userId,
   });
 
@@ -56,6 +57,7 @@ export default function CreatedCollectionList({
     collectionId: selectedCollection?.id,
     searchValue: searchPostValue,
     queryOptions: {
+      refetchOnMount: "always",
       enabled: !!selectedCollection,
     },
   });

--- a/web/src/components/Layout/Profile/CreatedImageList.tsx
+++ b/web/src/components/Layout/Profile/CreatedImageList.tsx
@@ -28,6 +28,7 @@ export default function CreatedImageList({
     userId,
     recentOnly: true,
     queryOptions: {
+      refetchOnMount: "always",
       enabled: !!userId,
     },
   });

--- a/web/src/pages/api/user/update.ts
+++ b/web/src/pages/api/user/update.ts
@@ -80,11 +80,9 @@ async function uploadImage(image: string, res: NextApiResponse) {
   // Resize and compress the image before uploading it to imgur
   // Sharp will resize both images and animated gifs
   const uri = image.split(";base64,").at(-1) as string;
-  const resizedImage = await sharp(Buffer.from(uri, "base64"), {
-    animated: true,
-  })
+  const resizedImage = await sharp(Buffer.from(uri, "base64"))
     .resize(192, 192)
-    .gif({ colors: 128 })
+    .png({ quality: 90 })
     .toBuffer()
     .catch((err) => {
       console.error(err);

--- a/web/src/pages/api/user/update.ts
+++ b/web/src/pages/api/user/update.ts
@@ -78,7 +78,8 @@ export default async function update(req: Request, res: NextApiResponse) {
 
 async function uploadImage(image: string, res: NextApiResponse) {
   // Resize and compress the image before uploading it to imgur
-  // Sharp will resize both images and animated gifs
+  // Sharp will resize both images and animated gifs if the animated: true option is set
+  // However, for the purposes of optimizing the image for the web, we will only use the first frame of a gif and convert it to a png
   const uri = image.split(";base64,").at(-1) as string;
   const resizedImage = await sharp(Buffer.from(uri, "base64"))
     .resize(192, 192)


### PR DESCRIPTION
Next.js won't optimize gifs and as such it is best to avoid them altogether as they are fetched in their unoptimized original size